### PR TITLE
Add system socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Rsync cookbook with rsyncd LWRP. More info on ryncd options can be found in the 
 
 The name of the init service
 
+`node['rsyncd']['init']` _(String) default: "sysvinit(for Debian platform and Redhat platform without systemd)/systemd (for Redhat platform supporting systemd )"_
+
+The name of the init mode (Currently supporting **systemd/sysvinit**)
+
 `node['rsyncd']['config']` _(Hash) default: "/etc/rsyncd.conf"_
 
 Path to the rsyncd config file. This is the default, but the serve resource can write config files to arbitrary paths independant of this.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,10 +15,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 #
-
+srv_provider = ::Chef::Platform::ServiceHelpers.service_resource_providers
+default['rsyncd']['init'] = if srv_provider.include?(:systemd)
+                              'systemd'
+                            else
+                              'sysvinit'
+                            end
 default['rsyncd']['service'] = case node['platform_family']
                                when 'rhel'
-                                 'rsyncd'
+                                 # Currently only RHEL platform allow the use
+                                 # of the systemd socket for rsyncd
+                                 case node['rsyncd']['init']
+                                 when 'systemd'
+                                   'rsyncd.socket'
+                                 when 'sysvinit'
+                                   'rsyncd'
+                                 end
                                when 'debian'
                                  'rsync'
                                else

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -26,6 +26,8 @@ when 'rhel'
     owner  'root'
     group  'root'
     mode   '0755'
+    # Redhat/CentOS 7 provide a systemd socket unit for rsyncd
+    not_if { node['rsyncd']['init'] == 'systemd' }
   end
 when 'debian'
   template '/etc/default/rsync' do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -6,34 +6,56 @@ describe 'rsync::server' do
     allow(File).to receive(:exist?).with('/etc/rsyncd.conf').and_return(true)
   end
 
-  context 'on rhel' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8').converge('rsync::server')
-    end
-
-    it 'includes the default recipe' do
-      expect(chef_run).to include_recipe('rsync::default')
-    end
-
-    context '/etc/init.d/rsyncd template' do
-      let(:template) { chef_run.template('/etc/init.d/rsyncd') }
-
-      it 'writes the template' do
-        expect(chef_run).to render_file('/etc/init.d/rsyncd').with_content('Rsyncd init script')
+  {
+    '6.8' => %i(upstart redhat),
+    '7.4.1708' => %i(redhat systemd),
+  }.each do |os_version, service_providers|
+    context "on rhel #{os_version}" do
+      before do
+        mock_service_resource_providers(service_providers)
       end
 
-      it 'is owned by root:root' do
-        expect(template.owner).to eq('root')
-        expect(template.group).to eq('root')
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'centos',
+          platform_family: 'rhel',
+          version: os_version
+        ).converge('rsync::server')
       end
 
-      it 'has the correct permissions' do
-        expect(template.mode).to eq('0755')
+      it 'includes the default recipe' do
+        expect(chef_run).to include_recipe('rsync::default')
       end
-    end
 
-    it 'starts and enables the rsync service' do
-      expect(chef_run).to enable_service('rsyncd')
+      context '/etc/init.d/rsyncd template' do
+        let(:template) { chef_run.template('/etc/init.d/rsyncd') }
+
+        case os_version
+        when /^6/
+          it 'writes the template' do
+            expect(chef_run).to render_file('/etc/init.d/rsyncd').with_content('Rsyncd init script')
+          end
+
+          it 'is owned by root:root' do
+            expect(template.owner).to eq('root')
+            expect(template.group).to eq('root')
+          end
+
+          it 'has the correct permissions' do
+            expect(template.mode).to eq('0755')
+          end
+        else
+          it 'not to write template' do
+            expect(chef_run).not_to render_file('/etc/init.d/rsyncd')
+          end
+        end
+      end
+      context 'rsyncd services' do
+        service_name = os_version =~ /^6/ ? 'rsyncd' : 'rsyncd.socket'
+        it "starts and enables the #{service_name} service" do
+          expect(chef_run).to enable_service(service_name)
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,7 @@ RSpec.configure do |config|
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
 end
+
+def mock_service_resource_providers(hints)
+  allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return(hints)
+end


### PR DESCRIPTION
Hello

### Description
Enable systemd support for rsyncd as available on RHEL platform (Redhat 7/CentOS 7)

### Check List
- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
